### PR TITLE
telescope-v0.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,21 @@ if (ZLIB_FOUND)
   target_link_libraries(telescope libtelescope ${ZLIB_LIBRARIES})
 endif()
 
-## Check dependencies and download them if not found
+## Check dependencies
+find_package(OpenMP)
+if (OPENMP_FOUND)
+  set(TELESCOPE_OPENMP_SUPPORT 1)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_PARALLEL")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -D_GLIBCXX_PARALLEL")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -D_GLIBCXX_PARALLEL")
+else()
+  set(TELESCOPE_OPENMP_SUPPORT 0)
+endif()
 
+## Configure OpenMP if it is supported on the system.
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config/telescope_openmp_config.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/include/telescope_openmp_config.hpp @ONLY)
+
+## Check and and download them if not found
 ## BitMagic - supplied with the project
 ## BitMagic
 if (DEFINED CMAKE_BITMAGIC_HEADERS)
@@ -216,3 +229,8 @@ endif()
 
 ## Generate a telescope_version.h file containing build version and timestamp
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config/telescope_version.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/telescope_version.h @ONLY)
+
+# Link libraries
+if (OPENMP_FOUND)
+  target_link_libraries(libtelescope OpenMP::OpenMP_CXX)
+endif()

--- a/config/telescope_openmp_config.hpp.in
+++ b/config/telescope_openmp_config.hpp.in
@@ -1,0 +1,35 @@
+// mSWEEP: Estimate abundances of reference lineages in DNA sequencing reads.
+//
+// MIT License
+//
+// Copyright (c) 2023 Probabilistic Inference and Computational Biology group @ UH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+#ifndef TELESCOPE_OPENMP_CONFIG_HPP
+#define TELESCOPE_OPENMP_CONFIG_HPP
+
+#define TELESCOPE_OPENMP_SUPPORT @TELESCOPE_OPENMP_SUPPORT@
+
+#if defined(TELESCOPE_OPENMP_SUPPORT) && (TELESCOPE_OPENMP_SUPPORT) == 1
+#include <omp.h>
+#endif
+
+
+#endif

--- a/include/Alignment.hpp
+++ b/include/Alignment.hpp
@@ -100,6 +100,8 @@ public:
   // Get the IDs of reads assigned to an equivalence class
   const std::vector<uint32_t>& reads_assigned_to_ec(const size_t &ec_id) const { return this->aligned_reads[ec_id]; }
 
+  // Get all aligned reads
+  const std::vector<std::vector<uint32_t>>& get_aligned_reads() const { return this->aligned_reads; }
 };
 
 class ThemistoAlignment : public Alignment{

--- a/include/Alignment.hpp
+++ b/include/Alignment.hpp
@@ -86,6 +86,9 @@ public:
     ec_configs.freeze();
   }
 
+  // Check if `row` aligned against `col`.
+  virtual size_t operator()(const size_t row, const size_t col) const =0;
+
   // Get the total number of equivalence classes in the alignment
   size_t n_ecs() const { return ec_counts.size(); }
 
@@ -147,7 +150,7 @@ public:
   }
 
   // Check if ec_id `row` aligned against group `col`.
-  bool operator()(const size_t row, const size_t col) const { return this->ec_configs[row*this->n_refs + col]; }
+  size_t operator()(const size_t row, const size_t col) const override { return this->ec_configs[row*this->n_refs + col]; }
 
   // Collapse the stored pseudoalignment into equivalence classes and their observation counts.
   void collapse() { Alignment::collapse(this->ec_configs); }
@@ -217,6 +220,8 @@ public:
     size_t pos = ec_id*this->n_groups + group_id;
     return this->sparse_group_counts[pos];
   }
+
+  size_t operator()(const size_t row, const size_t col) const override { return this->get_group_count(row, col); }
 
 };
 }

--- a/include/Alignment.hpp
+++ b/include/Alignment.hpp
@@ -159,14 +159,14 @@ public:
   const bm::bvector<> &get_configs() const { return this->ec_configs; }
 };
 
-template <typename T>
+template <typename T, typename V>
 struct GroupedAlignment : public Alignment {
 private:
   // Total number of reference groups
   uint16_t n_groups;
 
   // Vector reference sequence at <position> to the group at <value>
-  std::vector<uint32_t> group_indicators;
+  std::vector<V> group_indicators;
 
   // Number of sequences in each group that reads belonging to an
   // equivalence class aligned against.
@@ -178,10 +178,10 @@ private:
     std::unordered_map<std::vector<bool>, uint32_t>::iterator it = ec_to_pos->find(current_ec);
     if (it == ec_to_pos->end()) {
       this->ec_counts.emplace_back(0);
-      it = ec_to_pos->insert(std::make_pair(current_ec, *ec_id)).first;
+      it = ec_to_pos->insert(std::make_pair(current_ec, (uint32_t)*ec_id)).first;
 
       size_t read_start = (*ec_id)*this->n_groups;
-      for (uint32_t j = 0; j  < this->n_refs; ++j) {
+      for (size_t j = 0; j  < this->n_refs; ++j) {
 	if (current_ec[j]) {
 	  this->sparse_group_counts.inc(read_start + this->group_indicators[j]);
 	}
@@ -199,7 +199,7 @@ public:
     this->sparse_group_counts = bm::sparse_vector<T, bm::bvector<>>();
   }
 
-  GroupedAlignment(const size_t _n_refs, const size_t _n_groups, const std::vector<uint32_t> _group_indicators) {
+  GroupedAlignment(const size_t _n_refs, const size_t _n_groups, const std::vector<V> _group_indicators) {
     this->n_refs = _n_refs;
     this->n_groups = _n_groups;
     this->group_indicators = _group_indicators;
@@ -207,7 +207,7 @@ public:
     this->sparse_group_counts = bm::sparse_vector<T, bm::bvector<>>();
   }
 
-  GroupedAlignment(const size_t _n_refs, const size_t _n_groups, const size_t _n_reads, const std::vector<uint32_t> _group_indicators) {
+  GroupedAlignment(const size_t _n_refs, const size_t _n_groups, const size_t _n_reads, const std::vector<V> _group_indicators) {
     this->n_refs = _n_refs;
     this->n_groups = _n_groups;
     this->group_indicators = _group_indicators;

--- a/include/Alignment.hpp
+++ b/include/Alignment.hpp
@@ -156,6 +156,7 @@ public:
   const bm::bvector<> &get_configs() const { return this->ec_configs; }
 };
 
+template <typename T>
 struct GroupedAlignment : public Alignment {
 private:
   // Total number of reference groups
@@ -166,7 +167,7 @@ private:
 
   // Number of sequences in each group that reads belonging to an
   // equivalence class aligned against.
-  bm::sparse_vector<uint16_t, bm::bvector<>> sparse_group_counts;
+  bm::sparse_vector<T, bm::bvector<>> sparse_group_counts;
 
   // Implement insert() from the base class
   void insert(const std::vector<bool> &current_ec, const size_t &i, size_t *ec_id, std::unordered_map<std::vector<bool>, uint32_t> *ec_to_pos, bm::bvector<>::bulk_insert_iterator*) override {
@@ -192,7 +193,7 @@ private:
 public:
   // Default constructor
   GroupedAlignment() {
-    this->sparse_group_counts = bm::sparse_vector<uint16_t, bm::bvector<>>();
+    this->sparse_group_counts = bm::sparse_vector<T, bm::bvector<>>();
   }
 
   GroupedAlignment(const size_t _n_refs, const size_t _n_groups, const std::vector<uint32_t> _group_indicators) {
@@ -200,7 +201,7 @@ public:
     this->n_groups = _n_groups;
     this->group_indicators = _group_indicators;
     this->n_processed = 0;
-    this->sparse_group_counts = bm::sparse_vector<uint16_t, bm::bvector<>>();
+    this->sparse_group_counts = bm::sparse_vector<T, bm::bvector<>>();
   }
 
   GroupedAlignment(const size_t _n_refs, const size_t _n_groups, const size_t _n_reads, const std::vector<uint32_t> _group_indicators) {
@@ -208,11 +209,11 @@ public:
     this->n_groups = _n_groups;
     this->group_indicators = _group_indicators;
     this->n_processed = _n_reads;
-    this->sparse_group_counts = bm::sparse_vector<uint16_t, bm::bvector<>>();
+    this->sparse_group_counts = bm::sparse_vector<T, bm::bvector<>>();
   }
 
   // Get the number of sequences in group_id that the ec_id aligned against.
-  uint16_t get_group_count(const size_t group_id, const size_t ec_id) const {
+  T get_group_count(const size_t group_id, const size_t ec_id) const {
     size_t pos = ec_id*this->n_groups + group_id;
     return this->sparse_group_counts[pos];
   }

--- a/include/Alignment.hpp
+++ b/include/Alignment.hpp
@@ -193,7 +193,62 @@ private:
   }
 
 public:
+  // Default constructor
   GroupedAlignment() = default;
+
+  // Copy constructor
+  GroupedAlignment(const GroupedAlignment &other) {
+    this->n_groups = other.n_groups;
+    this->group_indicators = other.group_indicators;
+    this->sparse_group_counts.reset(new bm::sparse_vector<uint16_t, bm::bvector<>>(*other.sparse_group_counts.get()));
+
+    this->n_processed = other.n_processed;
+    this->n_refs = other.n_refs;
+    this->ec_counts = other.ec_counts;
+    this->aligned_reads = other.aligned_reads;
+  }
+
+  // Move constructor
+  GroupedAlignment(GroupedAlignment &&other) {
+    this->n_groups = other.n_groups;
+    this->group_indicators = std::move(other.group_indicators);
+    this->sparse_group_counts = std::move(other.sparse_group_counts);
+
+    this->n_processed = other.n_processed;
+    this->n_refs = other.n_refs;
+    this->ec_counts = std::move(other.ec_counts);
+    this->aligned_reads = std::move(other.aligned_reads);
+  }
+
+  // Copy assignment constructor
+  GroupedAlignment& operator=(const GroupedAlignment &other) {
+    if (&other != this) {
+      this->n_groups = other.n_groups;
+      this->group_indicators = other.group_indicators;
+      this->sparse_group_counts.reset(new bm::sparse_vector<uint16_t, bm::bvector<>>(*other.sparse_group_counts.get()));
+
+      this->n_processed = other.n_processed;
+      this->n_refs = other.n_refs;
+      this->ec_counts = other.ec_counts;
+      this->aligned_reads = other.aligned_reads;
+    }
+    return *this;
+  }
+
+  // Move assignment constructor
+  GroupedAlignment& operator=(GroupedAlignment &&other) {
+    if (&other != this) {
+      this->n_groups = other.n_groups;
+      this->group_indicators = std::move(other.group_indicators);
+      this->sparse_group_counts = std::move(other.sparse_group_counts);
+
+      this->n_processed = other.n_processed;
+      this->n_refs = other.n_refs;
+      this->ec_counts = std::move(other.ec_counts);
+      this->aligned_reads = std::move(other.aligned_reads);
+    }
+    return *this;
+  }
 
   GroupedAlignment(const size_t _n_refs, const size_t _n_groups, const std::vector<uint32_t> _group_indicators) {
     this->n_refs = _n_refs;

--- a/include/read_themisto_alignments.hpp
+++ b/include/read_themisto_alignments.hpp
@@ -22,34 +22,12 @@
 #include <cstddef>
 #include <vector>
 #include <fstream>
-#include <set>
-
-#include "bm64.h"
+#include <memory>
 
 #include "Alignment.hpp"
 #include "KallistoAlignment.hpp"
 
 namespace telescope {
-// telescope::ReadPairedAlignments
-//
-// Reads one or more pseudoalignment files from Themisto for
-// paired reads into `ec_configs`. Can be in plaintext or alignment-writer
-// format. Returns the number of reads (unaligned + aligned) in the
-// alignment.
-//
-// Input:
-//   `merge_op`: bm::set_OR for union or bm::set_AND for intersection of multiple alignmnet files
-//   `n_targets`: number of pseudoalignment targets (reference
-//                sequences). It's not possible to infer this from the plaintext Themisto
-//                file format so has to be provided separately. If the file is in the
-//                compact format will check that the numbers match.
-//   `streams`: vector of pointers to the istreams opened on the pseudoalignment files.
-//   `ec_configs`: pointer to the output variable that will contain the alignment.
-// Output:
-//   `n_reads`: total number of reads in the pseudoalignment (unaligned + aligned).
-//
-size_t ReadPairedAlignments(const bm::set_operation &merge_op, const size_t n_targets, std::vector<std::istream*> &streams, bm::bvector<> *ec_configs);
-
 namespace read {
 // Functions for reading pseudoalignment files into telescope::Alignment objects.
 
@@ -107,43 +85,7 @@ ThemistoAlignment ThemistoPlain(const bm::set_operation &merge_op, const size_t 
 //   `streams`: vector of pointers to the istreams opened on the pseudoalignment files.
 // Output:
 //   `aln`: The pseudoalignment as a telescope::GroupedAlignment object.
-template <typename T>
-GroupedAlignment<T> ThemistoGrouped(const bm::set_operation &merge_op, const size_t n_refs, const std::vector<uint32_t> &group_indicators, std::vector<std::istream*> &streams) {
-  // telescope::read::ThemistoGrouped
-  //
-  // Read in a Themisto pseudoalignment and collapse it into
-  // equivalence classes. Reads that align to the same number of
-  // reference sequences in each reference group (defined by
-  // `group_indicators`) are assigned to the same equivalence class.
-  //
-  // Input:
-  //   `merge_op`: bm::set_OR for union or bm::set_AND for intersection of multiple alignmnet files
-  //   `n_refs`: number of pseudoalignment targets (reference
-  //                sequences). It's not possible to infer this from the plaintext Themisto
-  //                file format so has to be provided separately. If the file is in the
-  //                compact format will check that the numbers match.
-  //   `group_indicators`: Vector assigning each reference sequence to a reference group. The group
-  //                       of the n:th sequence is the value at the (n - 1):th position in the vector.
-  //   `streams`: vector of pointers to the istreams opened on the pseudoalignment files.
-  // Output:
-  //   `aln`: The pseudoalignment as a telescope::GroupedAlignment object.
-  //
-
-  // Count the number of distinct reference groups
-  std::set<uint32_t> reference_group_ids;
-  for (size_t i = 0; i < group_indicators.size(); ++i) {
-    reference_group_ids.insert(group_indicators[i]);
-  }
-  size_t n_groups = reference_group_ids.size();
-
-  // Read the alignment
-  bm::bvector<> ec_configs(bm::BM_GAP);
-  size_t n_reads = ReadPairedAlignments(merge_op, n_refs, streams, &ec_configs);
-  GroupedAlignment<T> aln(n_refs, n_groups, n_reads, group_indicators);
-  aln.collapse(ec_configs);
-
-  return aln;
-}
+void ThemistoGrouped(const bm::set_operation &merge_op, const size_t n_refs, const std::vector<uint32_t> &group_indicators, std::vector<std::istream*> &streams, std::unique_ptr<Alignment> &aln);
 
 // telescope::read::ThemistoToKallisto
 //

--- a/include/read_themisto_alignments.hpp
+++ b/include/read_themisto_alignments.hpp
@@ -23,11 +23,45 @@
 #include <vector>
 #include <fstream>
 #include <memory>
+#include <set>
 
 #include "Alignment.hpp"
 #include "KallistoAlignment.hpp"
 
 namespace telescope {
+// telescope::ReadPairedAlignments
+//
+// Reads one or more pseudoalignment files from Themisto for
+// paired reads into `ec_configs`. Can be in plaintext or alignment-writer
+// format. Returns the number of reads (unaligned + aligned) in the
+// alignment.
+//
+// Input:
+//   `merge_op`: bm::set_OR for union or bm::set_AND for intersection of multiple alignmnet files
+//   `n_targets`: number of pseudoalignment targets (reference
+//                sequences). It's not possible to infer this from the plaintext Themisto
+//                file format so has to be provided separately. If the file is in the
+//                compact format will check that the numbers match.
+//   `streams`: vector of pointers to the istreams opened on the pseudoalignment files.
+//   `ec_configs`: pointer to the output variable that will contain the alignment.
+// Output:
+//   `n_reads`: total number of reads in the pseudoalignment (unaligned + aligned).
+//
+size_t ReadPairedAlignments(const bm::set_operation &merge_op, const size_t n_targets, std::vector<std::istream*> &streams, bm::bvector<> *ec_configs);
+
+template<typename T>
+size_t get_max_size(const std::vector<T> &group_indicators, const size_t n_groups) {
+  std::vector<size_t> sizes(n_groups, 0);
+  for (size_t i = 0; i < group_indicators.size(); ++i) {
+    ++sizes[group_indicators[i]];
+  }
+  size_t max_size = 0;
+  for (size_t i = 0; i < n_groups; ++i) {
+    max_size = (sizes[i] > max_size ? sizes[i] : max_size);
+  }
+  return max_size;
+}
+
 namespace read {
 // Functions for reading pseudoalignment files into telescope::Alignment objects.
 
@@ -85,7 +119,40 @@ ThemistoAlignment ThemistoPlain(const bm::set_operation &merge_op, const size_t 
 //   `streams`: vector of pointers to the istreams opened on the pseudoalignment files.
 // Output:
 //   `aln`: The pseudoalignment as a telescope::GroupedAlignment object.
-void ThemistoGrouped(const bm::set_operation &merge_op, const size_t n_refs, const std::vector<uint32_t> &group_indicators, std::vector<std::istream*> &streams, std::unique_ptr<Alignment> &aln);
+//   `streams`: vector of pointers to the istreams opened on the pseudoalignment files.
+// Output:
+//   `aln`: The pseudoalignment as a telescope::GroupedAlignment object.
+//
+template<typename T>
+void ThemistoGrouped(const bm::set_operation &merge_op, const size_t n_refs, const std::vector<T> &group_indicators, std::vector<std::istream*> &streams, std::unique_ptr<Alignment> &aln) {
+      //   `streams`: vector of pointers to the istreams opened on the pseudoalignment files.
+  // Output:
+  //   `aln`: The pseudoalignment as a telescope::GroupedAlignment object.
+  //
+
+  // Count the number of distinct reference groups
+  std::set<T> reference_group_ids;
+  for (size_t i = 0; i < group_indicators.size(); ++i) {
+    reference_group_ids.insert(group_indicators[i]);
+  }
+  size_t n_groups = reference_group_ids.size();
+  size_t max_size = get_max_size(group_indicators, n_groups);
+
+  // Read the alignment
+  bm::bvector<> ec_configs(bm::BM_GAP);
+  size_t n_reads = ReadPairedAlignments(merge_op, n_refs, streams, &ec_configs);
+
+  if (max_size <= std::numeric_limits<uint8_t>::max()) {
+    aln.reset(new GroupedAlignment<uint8_t, T>(n_refs, n_groups, n_reads, group_indicators));
+  } else if (max_size <= std::numeric_limits<uint16_t>::max()) {
+    aln.reset(new GroupedAlignment<uint16_t, T>(n_refs, n_groups, n_reads, group_indicators));
+  } else if (max_size <= std::numeric_limits<uint32_t>::max()) {
+    aln.reset(new GroupedAlignment<uint32_t, T>(n_refs, n_groups, n_reads, group_indicators));
+  } else {
+    aln.reset(new GroupedAlignment<uint64_t, T>(n_refs, n_groups, n_reads, group_indicators));
+  }
+  aln->collapse(ec_configs);
+}
 
 // telescope::read::ThemistoToKallisto
 //

--- a/src/read_themisto_alignments.cpp
+++ b/src/read_themisto_alignments.cpp
@@ -140,7 +140,18 @@ size_t ReadAlignmentFile(const size_t n_targets, std::istream *stream, bm::bvect
     }
     // Size is given on the header line.
     ec_configs->resize(n_reads*n_refs);
-    ReadCompactAlignment(stream, ec_configs);
+    size_t n_threads = 1;
+#if defined(TELESCOPE_OPENMP_SUPPORT) && (TELESCOPE_OPENMP_SUPPORT) == 1
+    #pragma omp parallel
+    {
+	n_threads = omp_get_num_threads();
+    }
+#endif
+    if (n_threads > 1) {
+	alignment_writer::ParallelUnpackData(stream, ec_configs);
+    } else {
+	alignment_writer::UnpackData(stream, ec_configs);
+    }
   } else {
     // Stream could be in the plaintext format.
     // Size is unknown.

--- a/src/read_themisto_alignments.cpp
+++ b/src/read_themisto_alignments.cpp
@@ -201,18 +201,6 @@ size_t ReadPairedAlignments(const bm::set_operation &merge_op, const size_t n_ta
   return n_reads;
 }
 
-size_t get_max_size(const std::vector<uint32_t> &group_indicators, const size_t n_groups) {
-  std::vector<size_t> sizes(n_groups, 0);
-  for (size_t i = 0; i < group_indicators.size(); ++i) {
-    ++sizes[group_indicators[i]];
-  }
-  size_t max_size = 0;
-  for (size_t i = 0; i < n_groups; ++i) {
-    max_size = (sizes[i] > max_size ? sizes[i] : max_size);
-  }
-  return max_size;
-}
-
 namespace read {
 ThemistoAlignment Themisto(const bm::set_operation &merge_op, const size_t n_refs, std::vector<std::istream*> &streams) {
   // telescope::read::Themisto
@@ -258,51 +246,6 @@ ThemistoAlignment ThemistoPlain(const bm::set_operation &merge_op, const size_t 
   size_t n_reads = ReadPairedAlignments(merge_op, n_refs, streams, &ec_configs);
   ThemistoAlignment aln(n_refs, n_reads, ec_configs);
   return aln;
-}
-
-void ThemistoGrouped(const bm::set_operation &merge_op, const size_t n_refs, const std::vector<uint32_t> &group_indicators, std::vector<std::istream*> &streams, std::unique_ptr<Alignment> &aln) {
-  // telescope::read::ThemistoGrouped
-  //
-  // Read in a Themisto pseudoalignment and collapse it into
-  // equivalence classes. Reads that align to the same number of
-  // reference sequences in each reference group (defined by
-  // `group_indicators`) are assigned to the same equivalence class.
-  //
-  // Input:
-  //   `merge_op`: bm::set_OR for union or bm::set_AND for intersection of multiple alignmnet files
-  //   `n_refs`: number of pseudoalignment targets (reference
-  //                sequences). It's not possible to infer this from the plaintext Themisto
-  //                file format so has to be provided separately. If the file is in the
-  //                compact format will check that the numbers match.
-  //   `group_indicators`: Vector assigning each reference sequence to a reference group. The group
-  //                       of the n:th sequence is the value at the (n - 1):th position in the vector.
-  //   `streams`: vector of pointers to the istreams opened on the pseudoalignment files.
-  // Output:
-  //   `aln`: The pseudoalignment as a telescope::GroupedAlignment object.
-  //
-
-  // Count the number of distinct reference groups
-  std::set<uint32_t> reference_group_ids;
-  for (size_t i = 0; i < group_indicators.size(); ++i) {
-    reference_group_ids.insert(group_indicators[i]);
-  }
-  size_t n_groups = reference_group_ids.size();
-  size_t max_size = get_max_size(group_indicators, n_groups);
-
-  // Read the alignment
-  bm::bvector<> ec_configs(bm::BM_GAP);
-  size_t n_reads = ReadPairedAlignments(merge_op, n_refs, streams, &ec_configs);
-
-  if (max_size <= std::numeric_limits<uint8_t>::max()) {
-    aln.reset(new GroupedAlignment<uint8_t>(n_refs, n_groups, n_reads, group_indicators));
-  } else if (max_size <= std::numeric_limits<uint16_t>::max()) {
-    aln.reset(new GroupedAlignment<uint16_t>(n_refs, n_groups, n_reads, group_indicators));
-  } else if (max_size <= std::numeric_limits<uint32_t>::max()) {
-    aln.reset(new GroupedAlignment<uint32_t>(n_refs, n_groups, n_reads, group_indicators));
-  } else {
-    aln.reset(new GroupedAlignment<uint64_t>(n_refs, n_groups, n_reads, group_indicators));
-  }
-  aln->collapse(ec_configs);
 }
 
 KallistoAlignment ThemistoToKallisto(const bm::set_operation &merge_op, const size_t n_refs, std::vector<std::istream*> &streams) {

--- a/src/read_themisto_alignments.cpp
+++ b/src/read_themisto_alignments.cpp
@@ -150,9 +150,9 @@ size_t ReadAlignmentFile(const size_t n_targets, std::istream *stream, bm::bvect
     }
 #endif
     if (n_threads > 1) {
-	alignment_writer::ParallelUnpackData(stream, ec_configs);
+	alignment_writer::ParallelUnpackData(stream, *ec_configs);
     } else {
-	alignment_writer::UnpackData(stream, ec_configs);
+	alignment_writer::UnpackData(stream, *ec_configs);
     }
   } else {
     // Stream could be in the plaintext format.

--- a/src/read_themisto_alignments.cpp
+++ b/src/read_themisto_alignments.cpp
@@ -20,9 +20,7 @@
 
 #include <string>
 #include <sstream>
-#include <set>
 
-#include "bm64.h"
 #include "unpack.hpp"
 
 #include "telescope.hpp"
@@ -244,43 +242,6 @@ ThemistoAlignment ThemistoPlain(const bm::set_operation &merge_op, const size_t 
   bm::bvector<> ec_configs(bm::BM_GAP);
   size_t n_reads = ReadPairedAlignments(merge_op, n_refs, streams, &ec_configs);
   ThemistoAlignment aln(n_refs, n_reads, ec_configs);
-  return aln;
-}
-
-GroupedAlignment ThemistoGrouped(const bm::set_operation &merge_op, const size_t n_refs, const std::vector<uint32_t> &group_indicators, std::vector<std::istream*> &streams) {
-  // telescope::read::ThemistoGrouped
-  //
-  // Read in a Themisto pseudoalignment and collapse it into
-  // equivalence classes. Reads that align to the same number of
-  // reference sequences in each reference group (defined by
-  // `group_indicators`) are assigned to the same equivalence class.
-  //
-  // Input:
-  //   `merge_op`: bm::set_OR for union or bm::set_AND for intersection of multiple alignmnet files
-  //   `n_refs`: number of pseudoalignment targets (reference
-  //                sequences). It's not possible to infer this from the plaintext Themisto
-  //                file format so has to be provided separately. If the file is in the
-  //                compact format will check that the numbers match.
-  //   `group_indicators`: Vector assigning each reference sequence to a reference group. The group
-  //                       of the n:th sequence is the value at the (n - 1):th position in the vector.
-  //   `streams`: vector of pointers to the istreams opened on the pseudoalignment files.
-  // Output:
-  //   `aln`: The pseudoalignment as a telescope::GroupedAlignment object.
-  //
-
-  // Count the number of distinct reference groups
-  std::set<uint32_t> reference_group_ids;
-  for (size_t i = 0; i < group_indicators.size(); ++i) {
-    reference_group_ids.insert(group_indicators[i]);
-  }
-  size_t n_groups = reference_group_ids.size();
-
-  // Read the alignment
-  bm::bvector<> ec_configs(bm::BM_GAP);
-  size_t n_reads = ReadPairedAlignments(merge_op, n_refs, streams, &ec_configs);
-  GroupedAlignment aln(n_refs, n_groups, n_reads, group_indicators);
-  aln.collapse(ec_configs);
-
   return aln;
 }
 

--- a/src/read_themisto_alignments.cpp
+++ b/src/read_themisto_alignments.cpp
@@ -20,7 +20,10 @@
 
 #include <string>
 #include <sstream>
+#include <set>
+#include <limits>
 
+#include "bm64.h"
 #include "unpack.hpp"
 
 #include "telescope.hpp"
@@ -198,6 +201,18 @@ size_t ReadPairedAlignments(const bm::set_operation &merge_op, const size_t n_ta
   return n_reads;
 }
 
+size_t get_max_size(const std::vector<uint32_t> &group_indicators, const size_t n_groups) {
+  std::vector<size_t> sizes(n_groups, 0);
+  for (size_t i = 0; i < group_indicators.size(); ++i) {
+    ++sizes[group_indicators[i]];
+  }
+  size_t max_size = 0;
+  for (size_t i = 0; i < n_groups; ++i) {
+    max_size = (sizes[i] > max_size ? sizes[i] : max_size);
+  }
+  return max_size;
+}
+
 namespace read {
 ThemistoAlignment Themisto(const bm::set_operation &merge_op, const size_t n_refs, std::vector<std::istream*> &streams) {
   // telescope::read::Themisto
@@ -243,6 +258,51 @@ ThemistoAlignment ThemistoPlain(const bm::set_operation &merge_op, const size_t 
   size_t n_reads = ReadPairedAlignments(merge_op, n_refs, streams, &ec_configs);
   ThemistoAlignment aln(n_refs, n_reads, ec_configs);
   return aln;
+}
+
+void ThemistoGrouped(const bm::set_operation &merge_op, const size_t n_refs, const std::vector<uint32_t> &group_indicators, std::vector<std::istream*> &streams, std::unique_ptr<Alignment> &aln) {
+  // telescope::read::ThemistoGrouped
+  //
+  // Read in a Themisto pseudoalignment and collapse it into
+  // equivalence classes. Reads that align to the same number of
+  // reference sequences in each reference group (defined by
+  // `group_indicators`) are assigned to the same equivalence class.
+  //
+  // Input:
+  //   `merge_op`: bm::set_OR for union or bm::set_AND for intersection of multiple alignmnet files
+  //   `n_refs`: number of pseudoalignment targets (reference
+  //                sequences). It's not possible to infer this from the plaintext Themisto
+  //                file format so has to be provided separately. If the file is in the
+  //                compact format will check that the numbers match.
+  //   `group_indicators`: Vector assigning each reference sequence to a reference group. The group
+  //                       of the n:th sequence is the value at the (n - 1):th position in the vector.
+  //   `streams`: vector of pointers to the istreams opened on the pseudoalignment files.
+  // Output:
+  //   `aln`: The pseudoalignment as a telescope::GroupedAlignment object.
+  //
+
+  // Count the number of distinct reference groups
+  std::set<uint32_t> reference_group_ids;
+  for (size_t i = 0; i < group_indicators.size(); ++i) {
+    reference_group_ids.insert(group_indicators[i]);
+  }
+  size_t n_groups = reference_group_ids.size();
+  size_t max_size = get_max_size(group_indicators, n_groups);
+
+  // Read the alignment
+  bm::bvector<> ec_configs(bm::BM_GAP);
+  size_t n_reads = ReadPairedAlignments(merge_op, n_refs, streams, &ec_configs);
+
+  if (max_size <= std::numeric_limits<uint8_t>::max()) {
+    aln.reset(new GroupedAlignment<uint8_t>(n_refs, n_groups, n_reads, group_indicators));
+  } else if (max_size <= std::numeric_limits<uint16_t>::max()) {
+    aln.reset(new GroupedAlignment<uint16_t>(n_refs, n_groups, n_reads, group_indicators));
+  } else if (max_size <= std::numeric_limits<uint32_t>::max()) {
+    aln.reset(new GroupedAlignment<uint32_t>(n_refs, n_groups, n_reads, group_indicators));
+  } else {
+    aln.reset(new GroupedAlignment<uint64_t>(n_refs, n_groups, n_reads, group_indicators));
+  }
+  aln->collapse(ec_configs);
 }
 
 KallistoAlignment ThemistoToKallisto(const bm::set_operation &merge_op, const size_t n_refs, std::vector<std::istream*> &streams) {

--- a/src/read_themisto_alignments.cpp
+++ b/src/read_themisto_alignments.cpp
@@ -26,6 +26,8 @@
 #include "bm64.h"
 #include "unpack.hpp"
 
+#include "telescope_openmp_config.hpp"
+
 #include "telescope.hpp"
 
 namespace telescope {

--- a/src/read_themisto_alignments.cpp
+++ b/src/read_themisto_alignments.cpp
@@ -132,6 +132,11 @@ size_t ReadAlignmentFile(const size_t n_targets, std::istream *stream, bm::bvect
     // First line contains a ','; stream could be in the compact format.
     size_t n_refs;
     alignment_writer::ReadHeader(line, &n_reads, &n_refs);
+    if (n_refs > n_targets) {
+      throw std::runtime_error("Pseudoalignment file has more target sequences than expected.");
+    } else if (n_targets < n_refs) {
+      throw std::runtime_error("Pseudoalignment file has less target sequences than expected.");
+    }
     // Size is given on the header line.
     ec_configs->resize(n_reads*n_refs);
     ReadCompactAlignment(stream, ec_configs);


### PR DESCRIPTION
- Automatically detect file format for compact or plaintext alignments.
- Use parallel functions from [alignment-writer](https://github.com/tmaklin/alignment-writer) to read the pseudoalignment.
- Reimplement GroupedAlignment as a template, where the template parameter determines the size integer width required to store the group counts matrix.
- Size GroupedAlignment adaptively when initialized using `telescope::read::ThemistoGrouped`.